### PR TITLE
兼容PHP 8.2

### DIFF
--- a/src/XdbSearcher.php
+++ b/src/XdbSearcher.php
@@ -129,7 +129,7 @@ class XdbSearcher
             // read the vector index block
             $buff = $this->read(self::HeaderInfoLength + $idx, 8);
             if ($buff === null) {
-                throw new \Exception("failed to read vector index at ${idx}");
+                throw new \Exception("failed to read vector index at {$idx}");
             }
 
             $sPtr = self::getLong($buff, 0);
@@ -150,7 +150,7 @@ class XdbSearcher
             // read the segment index
             $buff = $this->read($p, self::SegmentIndexSize);
             if ($buff == null) {
-                throw new \Exception("failed to read segment index at ${p}");
+                throw new \Exception("failed to read segment index at {$p}");
             }
 
             $sip = self::getLong($buff, 0);
@@ -268,11 +268,11 @@ class XdbSearcher
 
         // return the decoded header info
         return [
-            'version' => self::getShort($buff, 0),
-            'indexPolicy' => self::getShort($buff, 2),
-            'createdAt' => self::getLong($buff, 4),
+            'version'       => self::getShort($buff, 0),
+            'indexPolicy'   => self::getShort($buff, 2),
+            'createdAt'     => self::getLong($buff, 4),
             'startIndexPtr' => self::getLong($buff, 8),
-            'endIndexPtr' => self::getLong($buff, 12)
+            'endIndexPtr'   => self::getLong($buff, 12)
         ];
     }
 


### PR DESCRIPTION
在PHP 8.2中 ${var} 字符串插入变量解析语法已被弃用，应将$放在花括号里面，否则将会抛出异常无法正常使用